### PR TITLE
Fix external logger with formatted messages

### DIFF
--- a/loggingpy/log.py
+++ b/loggingpy/log.py
@@ -259,7 +259,7 @@ class JsonFormatter(logging.Formatter):
             log_entry = LogEntry(log_level=LogLevel(record.levelno),
                                  context=record.name,
                                  payload_type='ExternalLoggerMessage',
-                                 data=record.msg)
+                                 data=(record.msg % (record.args)))
 
         dto = LogEntryParser.parse_log_entry(log_entry=log_entry)
 


### PR DESCRIPTION
For standard logger if you can actually do logger.debug("%s, %s %s", arg1, arg2, arg3).
This fix will handle this case.